### PR TITLE
Add dependency_logstore parameter support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ make build-all-darwin
 Please configure the log service according to the following steps.
 
 * Login on [Aliyun Log Service Web Console](https://sls.console.aliyun.com/#/). 
-* Create project, logstore for storing span.
+* Create project, logstores for storing span and dependency, respectively.
 * Create indexes for the following fields.
 
 | Field Name | Type | Token |
@@ -161,6 +161,7 @@ Parameter Description
 | aliyun-log.access-key-id | program argument | specify the account information for your log services |
 | aliyun-log.access-key-secret | program argument | specify the account information for your log services |
 | aliyun-log.span-logstore | program argument | specify the logstore used to store span |
+| aliyun-log.dependency-logstore | program argument | specify the logstore used to store dependency |
 
 At default settings the collector exposes the following ports:
 
@@ -182,7 +183,8 @@ docker run \
   --aliyun-log.endpoint=<ENDPOINT> \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
-  --aliyun-log.span-logstore=<SPAN_LOGSTORE>
+  --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE>
 ```
 
 If you have already built the corresponding binary file, take macOS as an example, you can run collector as follows:
@@ -193,7 +195,8 @@ export SPAN_STORAGE_TYPE=aliyun-log && \
   --aliyun-log.endpoint=<ENDPOINT> \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
-  --aliyun-log.span-logstore=<SPAN_LOGSTORE>
+  --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE>
 ```
 
 ### Query Service & UI
@@ -210,6 +213,7 @@ Parameters Description
 | aliyun-log.access-key-id | program argument | specify the account information for your log services |
 | aliyun-log.access-key-secret | program argument | specify the account information for your log services |
 | aliyun-log.span-logstore | program argument | specify the logstore used to store span |
+| aliyun-log.dependency-logstore | program argument | specify the logstore used to store dependency |
 | query.static-files | program argument | Specify the location of the UI static files |
 
 At default settings the query service exposes the following port(s):
@@ -231,6 +235,7 @@ docker run \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
   --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE> \
   --query.static-files=/go/jaeger-ui/
 ```
 
@@ -243,6 +248,7 @@ export SPAN_STORAGE_TYPE=aliyun-log && \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
   --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE> \
   --query.static-files=./jaeger-ui-build/build/
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -103,8 +103,8 @@ make build-all-darwin
 您需要按照以下步骤配置日志服务。
 
 * 登录 [日志服务管理控制台](https://sls.console.aliyun.com/#/)。
-* 创建用于存储 span 的 project、logstore。
-* 为下列字段创建索引。
+* 创建 project，创建用于存储 span 的 logstore 和用于存储 dependency 的 logstore。
+* 在存储 span 的 logstore 中为下列字段创建索引。
 
 | 字段名 | 类型 | 分词符 |
 | --- | --- | --- |
@@ -165,6 +165,7 @@ Collector 是无状态的，因此您可以同时运行任意数量的 jaeger-co
 | aliyun-log.access-key-id | 程序参数 | 指定用户标识 Access Key ID |
 | aliyun-log.access-key-secret | 程序参数 | 指定用户标识 Access Key Secret |
 | aliyun-log.span-logstore | 程序参数 | 指定用于存储 Span 的 Logstore |
+| aliyun-log.dependency-logstore | 程序参数 | 指定用于存储 Dependency 的 Logstore |
 
 默认情况下，collector 暴露如下端口
 
@@ -186,7 +187,8 @@ docker run \
   --aliyun-log.endpoint=<ENDPOINT> \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
-  --aliyun-log.span-logstore=<SPAN_LOGSTORE>
+  --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE>
 ```
 
 如果您已构建好相应的二进制文件，这里以 macOS 为例，可以使用如下方式运行 collector
@@ -197,7 +199,8 @@ export SPAN_STORAGE_TYPE=aliyun-log && \
   --aliyun-log.endpoint=<ENDPOINT> \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
-  --aliyun-log.span-logstore=<SPAN_LOGSTORE>
+  --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE>
 ```
 
 ### Query Service & UI
@@ -214,6 +217,7 @@ jaeger-query 提供了 API 端口以及 React/Javascript UI。该服务是无状
 | aliyun-log.access-key-id | 程序参数 | 指定用户标识 Access Key ID |
 | aliyun-log.access-key-secret | 程序参数 | 指定用户标识 Access Key Secret |
 | aliyun-log.span-logstore | 程序参数 | 指定用于存储 Span 的 Logstore |
+| aliyun-log.dependency-logstore | 程序参数 | 指定用于存储 Dependency 的 Logstore |
 | query.static-files | 程序参数 | 指定 UI 静态文件的位置 |
 
 默认情况下，query 暴露如下端口
@@ -235,6 +239,7 @@ docker run \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
   --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE> \
   --query.static-files=/go/jaeger-ui/
 ```
 
@@ -247,6 +252,7 @@ export SPAN_STORAGE_TYPE=aliyun-log && \
   --aliyun-log.access-key-id=<ACCESS_KEY_ID> \
   --aliyun-log.access-key-secret=<ACCESS_KEY_SECRET> \
   --aliyun-log.span-logstore=<SPAN_LOGSTORE> \
+  --aliyun-log.dependency-logstore=<DEPENDENCY_LOGSTORE> \
   --query.static-files=./jaeger-ui-build/build/
 ```
 
@@ -264,7 +270,7 @@ docker-compose -f aliyunlog-jaeger-docker-compose.yml up
 docker-compose -f aliyunlog-jaeger-docker-compose.yml stop
 ```
 
-**注意**：运行该命令之前请替换如下参数为真实值 ${PROJECT}、${ENDPOINT}、${ACCESS_KEY_ID}、${ACCESS_KEY_SECRET}、${SPAN_LOGSTORE}
+**注意**：运行该命令之前请替换如下参数为真实值 ${PROJECT}、${ENDPOINT}、${ACCESS_KEY_ID}、${ACCESS_KEY_SECRET}、${SPAN_LOGSTORE}、${DEPENDENCY_LOGSTORE}
 
 ## 示例
 

--- a/docker-compose/aliyunlog-jaeger-docker-compose.yml
+++ b/docker-compose/aliyunlog-jaeger-docker-compose.yml
@@ -5,7 +5,7 @@ services:
       image: registry.cn-hangzhou.aliyuncs.com/jaegertracing/jaeger-collector:0.0.1
       environment:
         - SPAN_STORAGE_TYPE=aliyun-log
-      command: ["/go/bin/collector-linux", "--aliyun-log.project=${PROJECT}", "--aliyun-log.endpoint=${ENDPOINT}", "--aliyun-log.access-key-id=${ACCESS_KEY_ID}", "--aliyun-log.access-key-secret=${ACCESS_KEY_SECRET}", "--aliyun-log.span-logstore=${SPAN_LOGSTORE}"]
+      command: ["/go/bin/collector-linux", "--aliyun-log.project=${PROJECT}", "--aliyun-log.endpoint=${ENDPOINT}", "--aliyun-log.access-key-id=${ACCESS_KEY_ID}", "--aliyun-log.access-key-secret=${ACCESS_KEY_SECRET}", "--aliyun-log.span-logstore=${SPAN_LOGSTORE}", "--aliyun-log.dependency-logstore=${DEPENDENCY_LOGSTORE}"]
       ports:
         - "14269"
         - "14268:14268"
@@ -17,7 +17,7 @@ services:
       image: registry.cn-hangzhou.aliyuncs.com/jaegertracing/jaeger-query:0.0.1
       environment:
         - SPAN_STORAGE_TYPE=aliyun-log
-      command: ["/go/bin/query-linux", "--query.static-files=/go/jaeger-ui/", "--aliyun-log.project=${PROJECT}", "--aliyun-log.endpoint=${ENDPOINT}", "--aliyun-log.access-key-id=${ACCESS_KEY_ID}", "--aliyun-log.access-key-secret=${ACCESS_KEY_SECRET}", "--aliyun-log.span-logstore=${SPAN_LOGSTORE}"]
+      command: ["/go/bin/query-linux", "--query.static-files=/go/jaeger-ui/", "--aliyun-log.project=${PROJECT}", "--aliyun-log.endpoint=${ENDPOINT}", "--aliyun-log.access-key-id=${ACCESS_KEY_ID}", "--aliyun-log.access-key-secret=${ACCESS_KEY_SECRET}", "--aliyun-log.span-logstore=${SPAN_LOGSTORE}", "--aliyun-log.dependency-logstore=${DEPENDENCY_LOGSTORE}"]
       ports:
         - "16686:16686"
         - "16687"

--- a/plugin/storage/aliyunlog/options.go
+++ b/plugin/storage/aliyunlog/options.go
@@ -23,12 +23,13 @@ import (
 )
 
 const (
-	suffixProject          = ".project"
-	suffixEndpoint         = ".endpoint"
-	suffixAccessKeyID      = ".access-key-id"
-	suffixAccessKeySecret  = ".access-key-secret"
-	suffixSpanLogstore     = ".span-logstore"
-	suffixMaxQueryDuration = ".max-query-duration"
+	suffixProject            = ".project"
+	suffixEndpoint           = ".endpoint"
+	suffixAccessKeyID        = ".access-key-id"
+	suffixAccessKeySecret    = ".access-key-secret"
+	suffixSpanLogstore       = ".span-logstore"
+	suffixDependencyLogstore = ".dependency-logstore"
+	suffixMaxQueryDuration   = ".max-query-duration"
 )
 
 // Options contains various type of AliCloud Log Service configs and provides the ability
@@ -100,6 +101,10 @@ func addFlags(flagSet *flag.FlagSet, nsConfig *namespaceConfig) {
 		nsConfig.namespace+suffixSpanLogstore,
 		nsConfig.SpanLogstore,
 		"The logstore to save span data in AliCloud Log Service")
+	flagSet.String(
+		nsConfig.namespace+suffixDependencyLogstore,
+		nsConfig.DependencyLogstore,
+		"The logstore to save dependency data in AliCloud Log Service")
 	flagSet.Duration(
 		nsConfig.namespace+suffixMaxQueryDuration,
 		nsConfig.MaxQueryDuration,
@@ -120,6 +125,7 @@ func initFromViper(cfg *namespaceConfig, v *viper.Viper) {
 	cfg.AccessKeyID = v.GetString(cfg.namespace + suffixAccessKeyID)
 	cfg.AccessKeySecret = v.GetString(cfg.namespace + suffixAccessKeySecret)
 	cfg.SpanLogstore = v.GetString(cfg.namespace + suffixSpanLogstore)
+	cfg.DependencyLogstore = v.GetString(cfg.namespace + suffixDependencyLogstore)
 	cfg.MaxQueryDuration = v.GetDuration(cfg.namespace + suffixMaxQueryDuration)
 }
 

--- a/plugin/storage/aliyunlog/options_test.go
+++ b/plugin/storage/aliyunlog/options_test.go
@@ -31,6 +31,7 @@ func TestOptions(t *testing.T) {
 	assert.Empty(t, primary.AccessKeyID)
 	assert.Empty(t, primary.AccessKeySecret)
 	assert.Equal(t, "jaeger-span", primary.SpanLogstore)
+	assert.Equal(t, "jaeger-dependency", primary.DependencyLogstore)
 	assert.Equal(t, 24*time.Hour, primary.MaxQueryDuration)
 
 	aux := opts.Get("archive")
@@ -39,6 +40,7 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, primary.AccessKeyID, aux.AccessKeyID)
 	assert.Equal(t, primary.AccessKeySecret, aux.AccessKeySecret)
 	assert.Equal(t, primary.SpanLogstore, aux.SpanLogstore)
+	assert.Equal(t, primary.DependencyLogstore, aux.DependencyLogstore)
 }
 
 func TestOptionsWithFlags(t *testing.T) {
@@ -50,6 +52,7 @@ func TestOptionsWithFlags(t *testing.T) {
 		"--aliyun-log.access-key-id=id-xxx",
 		"--aliyun-log.access-key-secret=secret-xxx",
 		"--aliyun-log.span-logstore=jaeger-span-store",
+		"--aliyun-log.dependency-logstore=jaeger-dependency-store",
 		"--aliyun-log.max-query-duration=48h",
 		// a couple overrides
 		"--aliyun-log.aux.project=my-jaeger-test-2",
@@ -65,6 +68,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "id-xxx", primary.AccessKeyID)
 	assert.Equal(t, "secret-xxx", primary.AccessKeySecret)
 	assert.Equal(t, "jaeger-span-store", primary.SpanLogstore)
+	assert.Equal(t, "jaeger-dependency-store", primary.DependencyLogstore)
 	assert.Equal(t, 48*time.Hour, primary.MaxQueryDuration)
 
 	aux := opts.Get("aliyun-log.aux")
@@ -73,6 +77,7 @@ func TestOptionsWithFlags(t *testing.T) {
 	assert.Equal(t, "id-yyy", aux.AccessKeyID)
 	assert.Equal(t, "secret-yyy", aux.AccessKeySecret)
 	assert.Equal(t, "jaeger-span-store", aux.SpanLogstore)
+	assert.Equal(t, "jaeger-dependency-store", aux.DependencyLogstore)
 	assert.Equal(t, 15*time.Minute, aux.MaxQueryDuration)
 
 }


### PR DESCRIPTION
I followed the readme instructions but got the blow error when deploying `jaeger-collector` in k8s.

```json
{"level":"fatal","ts":1525770109.113632,"caller":"collector/main.go:95","msg":"Failed to init storage factory","error":"{\n    \"errorCode\": \"ClientError\",\n    \"errorMessage\": \"{\\n    \\\"errorCode\\\": \\\"LogStoreNotExist\\\",\\n    \\\"errorMessage\\\": \\\"logstore jaeger-dependency dose not exist\\\"}
```

After digging into the code and discussing with Aliyun QA, I think It is caused by the prerequisite logstore for storing dependency is not created. The readme has no implications about the dependency logstore and there also has no ways to customize the logstore name, which is `jaeger-dependency` in default.

So I add an extra parameter `--aliyun-log.dependency-logstore` to support user-speficified dependency logstore name. Also provide the related instructions in readme.
