### PR TITLE
feat: marshal span logs

### DIFF
--- a/plugin/storage/aliyunlog/spanstore/reader.go
+++ b/plugin/storage/aliyunlog/spanstore/reader.go
@@ -39,6 +39,7 @@ const (
 	startTimeField     = "startTime"
 	durationField      = "duration"
 	tagsPrefix         = "tags."
+	logsField          = "logs"
 	serviceNameField   = "process.serviceName"
 	processTagsPrefix  = "process.tags."
 


### PR DESCRIPTION
添加 span logs 记录功能，会将 span 关联的 log 通过 json 格式序列化后发送到 aliyun sls. 如果需要在 sls 上查询这个字段（`logs`）可以通过 json 格式来查询（不过应该 sls 还不支持查询数组）

fix #2 